### PR TITLE
Improved performance in merge_teams_by_skills()

### DIFF
--- a/src/cmn/team.py
+++ b/src/cmn/team.py
@@ -1,6 +1,6 @@
 import os, scipy.sparse, pickle, numpy as np, logging
 from collections import Counter
-from functools import partial
+from functools import partial, reduce
 log = logging.getLogger(__name__)
 
 import pkgmgr as opentf
@@ -476,36 +476,23 @@ class Team(object):
         log.info(f'Merging teams whose subset of skills are the same ...')
 
         vecs = teamsvecs if inplace else copy.deepcopy(teamsvecs)
-        merge_list = {}
+        skills_rows_map = {} # {skill: [row indices]}
 
-        # in the following loop rows that have similar skills are founded
-        for i in range(len(vecs['skill'].rows)):
-            merge_list[f'{i}'] = set()
-            for j in range(i + 1, len(vecs['skill'].rows)):
-                if vecs['skill'].rows[i] == vecs['skill'].rows[j]: merge_list[f'{i}'].add(j)
-            if len(merge_list[f'{i}']) < 1: del merge_list[f'{i}']
-
-        delete_set = set()
-        for key in merge_list.keys():
-            for item in merge_list[key]: delete_set.add(item)
-
-        for item in delete_set:
-            try: del merge_list[f'{item}']
-            except KeyError: pass
+        for i in range(vecs['skill'].shape[0]):
+            current_skills = tuple(vecs['skill'].rows[i])
+            skills_rows_map.setdefault(current_skills, []).append(i)
 
         del_list = []
-        for key_ in merge_list.keys():
-            for value_ in merge_list[key_]:
-                del_list.append(value_)
-                vec1 = vecs['member'].getrow(int(key_))
-                vec2 = vecs['member'].getrow(value_)
-                result = np.add(vec1, vec2)
-                result[result != 0] = 1
-                vecs['member'][int(key_), :] = scipy.sparse.lil_matrix(result)
-                vecs['member'][int(value_), :] = scipy.sparse.lil_matrix(result)
+
+        for _, rows in skills_rows_map.items():
+            if len(rows) < 2: continue
+            del_list.extend(rows[1:])
+            new_members = reduce(lambda x, y: x.maximum(y), (vecs['member'].getrow(r) for r in rows))
+            for row in rows: vecs['member'][row, :] = new_members
         if distinct:
             vecs['skill'] = scipy.sparse.lil_matrix(np.delete(vecs['skill'].toarray(), del_list, axis=0))
             vecs['member'] = scipy.sparse.lil_matrix(np.delete(vecs['member'].toarray(), del_list, axis=0))
+
         return vecs
 
     @staticmethod


### PR DESCRIPTION
Hi @hosseinfani,
This is the PR for the first part of #310 which deals with improving the performance of `merge_teams_by_skills()`. With these improvements I was able to decrease runtime by 50% on both the toy dblp and toy imdb datasets.  

## Main Improvements
1. Changed to using a hashmap to detect the duplicate skills in the matrix.
2. Used `lil_matrix.maximum()` instead of `np.add()` when finding the combined member vector.

## Algorithm
1. If inplace=false, a copy of teamvecs is made. Otherwise, computations are done in place.
2. Create a `skills_rows_map` which is a dictionary (hash map) with the skill as the key, and row indices as the value. The skill is represented as a list of all non-zero elements in the skill row. The row indices are all the rows with the same skill vector.
3. For each group in the `skills_row_map`, the following is done.
	1. If there is only 1 row index, skip.
	2. Otherwise, compute the `maximum` of all the member vectors from the row indices together. The `maximum` essentially will compute logical OR between the vectors. This combined maximum is then set as the member for all the rows indicated in the row indices.
4. If distinct = true, then the rows that are same are deleted.
	1. the rows to delete are determined by `del_list`. This list is pretty much the row indices from every group in `skills_row_map` but excluding one of the row indices (the one excluded is the row to keep).

## Example
<img width="504" height="453" alt="image" src="https://github.com/user-attachments/assets/9e9e2e4a-119e-4077-8614-77a237270084" />


## Changes Made
- src/cmn/team.py -> modified `merge_teams_by_skills(...)`

