### PR TITLE
Increase Training Runtime When Merge is Done Beforehand

### DIFF
--- a/src/mdl/ntf.py
+++ b/src/mdl/ntf.py
@@ -21,8 +21,8 @@ class Ntf:
                 self.input, self.output = input_matrix, output_matrix
             def __len__(self): return self.input.shape[0]
             def __getitem__(self, index):
-                if scipy.sparse.issparse(self.input): return Ntf.torch.as_tensor(self.input[index].toarray()).float(), Ntf.torch.as_tensor(self.output[index].toarray()).float()
-                else: return Ntf.torch.as_tensor(self.input[index]).float(), Ntf.torch.as_tensor(self.output[index].toarray()).float()
+                if scipy.sparse.issparse(self.input): return Ntf.torch.as_tensor(self.input[index].tocsr().toarray()).float(), Ntf.torch.as_tensor(self.output[index].tocsr().toarray()).float()
+                else: return Ntf.torch.as_tensor(self.input[index]).float(), Ntf.torch.as_tensor(self.output[index].tocsr().toarray()).float()
         Ntf.dataset = NtfDataset
 
     def name(self): return f'/{self.__class__.__name__.lower()}.{opentf.cfg2str(self.cfg)}'


### PR DESCRIPTION
Hi @hosseinfani & @mahdis-saeedi, 
This is the PR for issue #310 for part 2 of the problem, which deals with the issue where the training runtime significantly increases when the merge is completed beforehand.

## Main Improvements
- In the `__getitem__()` which gives the tensors that used in training the model, I improved the performance of this action by converting the matrices from LIL to CSR format before converting to a dense vector. 
- This should hopefully help increase the performance of training. However, the toy datasets did give me a good representation of the time, so you'll have to run these on the full datasets.


## Changes Made
- src/mdl/ntf.py
	- in the `__getitem__(self, index)` function, I changed... 
		- `self.input[index].toarray()` to `self.input[index].tocsr().toarray()`
		- `self.output[index].toarray()` to `self.output[index].tocsr().toarray()`

